### PR TITLE
Add drag & drop, timers and multi-view modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Esta aplicación web permite jugar al ajedrez con diferentes modos de visualizac
 ## Uso
 
 1. Abre `index.html` en tu navegador.
-2. Presiona las teclas numéricas (1 a 4) para cambiar el modo de vista. Se aceptan tanto los dígitos del teclado principal como los del teclado numérico. No es necesario tener activado el bloqueo numérico:
-   - **1**: vista normal con movimientos disponibles al seleccionar una pieza.
-   - **2**: además de los movimientos, muestra las casillas atacadas por la pieza seleccionada.
-   - **3**: resalta nuestras piezas que están siendo atacadas.
-   - **4**: indica las casillas donde podemos dar jaque al rival.
-
-La partida se juega con click sobre las casillas. El turno comienza con blancas.
+2. Presiona las teclas numéricas (1 a 4) para alternar cada modo de vista. Puedes combinarlos:
+   - **1**: muestra los movimientos disponibles al seleccionar una pieza.
+   - **2**: resalta las casillas atacadas por la pieza seleccionada.
+   - **3**: señala nuestras piezas en peligro.
+   - **4**: indica las casillas desde las que podemos dar jaque.
+ 
+La partida se juega haciendo clic o arrastrando las piezas hasta su destino. El turno comienza con blancas. En todo momento se muestran las piezas capturadas y un contador de tiempo para cada bando.
 
 ## Reglas de juego
 

--- a/index.html
+++ b/index.html
@@ -12,8 +12,16 @@
 <body>
     <h1>Ajedrez Didáctico</h1>
     <div id="board" class="board"></div>
+    <div id="timer" class="timer">
+        <span>Blancas: <span id="timeWhite">00:00</span></span>
+        <span>Negras: <span id="timeBlack">00:00</span></span>
+    </div>
+    <div id="captured" class="captured">
+        <div>Capturas blancas: <span id="capturedWhite"></span></div>
+        <div>Capturas negras: <span id="capturedBlack"></span></div>
+    </div>
     <div id="info" class="info">
-        <p>Presiona 1 para ver movimientos, 2 para ver casillas atacadas, 3 para ver casillas propias en peligro, 4 para ver jaques posibles.</p>
+        <p>Presiona las teclas 1 a 4 para alternar las vistas. Se pueden combinar varias opciones a la vez.</p>
     </div>
     <button id="settingsToggle">Ajustes</button>
     <div id="settingsMenu" class="settings hidden">

--- a/src/styles.css
+++ b/src/styles.css
@@ -31,6 +31,16 @@ body {
     align-items: center;
     justify-content: center;
     font-size: var(--piece-size);
+    line-height: 1;
+}
+
+.piece {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    line-height: 1;
 }
 
 
@@ -111,4 +121,17 @@ h1 {
     font-size: var(--piece-size);
     pointer-events: none;
     transition: left 0.2s ease-out, top 0.2s ease-out;
+}
+
+.timer, .captured {
+    margin-top: 10px;
+    color: #cccccc;
+}
+
+.timer span {
+    margin: 0 5px;
+}
+
+.captured div {
+    margin-top: 5px;
 }


### PR DESCRIPTION
## Summary
- allow combining view modes and update instructions
- enable drag and drop piece movement
- show captured pieces and player timers
- center piece symbols better

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68618568241c8333b91788aa4fa77f4c