### PR TITLE
Improve interaction and visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Esta aplicación web permite jugar al ajedrez con diferentes modos de visualizac
 
 1. Abre `index.html` en tu navegador.
 2. Presiona las teclas numéricas (1 a 4) para alternar cada modo de vista. Puedes combinarlos:
-   - **1**: muestra los movimientos disponibles al seleccionar una pieza.
+   - **1**: muestra los movimientos disponibles al seleccionar o pasar el ratón sobre una pieza.
    - **2**: resalta las casillas atacadas por la pieza seleccionada.
    - **3**: señala nuestras piezas en peligro.
    - **4**: indica las casillas desde las que podemos dar jaque.
@@ -23,7 +23,8 @@ La partida se juega haciendo clic o arrastrando las piezas hasta su destino. El 
 
 Usa el botón **Ajustes** para abrir un panel donde puedes modificar:
 
-- El tamaño de las piezas mediante un control deslizante.
+- El tamaño de las piezas mediante un control deslizante (por defecto ahora se
+  muestran más grandes).
 - El brillo del color neón del tema oscuro.
 
 * **Capturas**: al mover a una casilla ocupada por una pieza rival, dicha pieza

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <button id="settingsToggle">Ajustes</button>
     <div id="settingsMenu" class="settings hidden">
         <label>Tamaño de pieza
-            <input type="range" id="pieceSize" min="24" max="72" value="32">
+            <input type="range" id="pieceSize" min="24" max="72" value="48">
         </label>
         <label>Brillo neón
             <input type="range" id="neonBrightness" min="30" max="70" value="55">

--- a/src/app.js
+++ b/src/app.js
@@ -59,6 +59,8 @@ function createBoard() {
             square.addEventListener('click', onSquareClick);
             square.addEventListener('dragover', e => e.preventDefault());
             square.addEventListener('drop', onDrop);
+            square.addEventListener('mouseenter', onSquareHover);
+            square.addEventListener('mouseleave', onSquareLeave);
             const pieceEl = document.createElement('span');
             pieceEl.classList.add('piece');
             pieceEl.addEventListener('dragstart', onDragStart);
@@ -91,6 +93,24 @@ function renderBoard() {
 
 function getSquareElement(row, col) {
     return boardElement.querySelector(`.square[data-row="${row}"][data-col="${col}"]`);
+}
+
+function onSquareHover(e) {
+    if (!activeViews.has(1) || selected) return;
+    const row = parseInt(e.currentTarget.dataset.row);
+    const col = parseInt(e.currentTarget.dataset.col);
+    const piece = board[row][col];
+    if (piece && isWhite(piece) === isWhiteTurn()) {
+        highlightMoves(row, col);
+    }
+}
+
+function onSquareLeave() {
+    if (!selected) {
+        renderBoard();
+    } else {
+        highlightMoves(selected.row, selected.col);
+    }
 }
 
 function onSquareClick(e) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,7 +3,7 @@
     --neon-s: 100%;
     --neon-l: 55%;
     --neon-color: hsl(var(--neon-h), var(--neon-s), var(--neon-l));
-    --piece-size: 32px;
+    --piece-size: 48px;
 }
 
 body {
@@ -41,6 +41,7 @@ body {
     width: 100%;
     height: 100%;
     line-height: 1;
+    vertical-align: middle;
 }
 
 


### PR DESCRIPTION
## Summary
- preview available moves when hovering a piece
- use larger pieces by default
- tweak CSS to better center pieces
- document hover behaviour and larger default size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686187f8f9b88333988e640974d8357f