### PR TITLE
Add active view indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Esta aplicación web permite jugar al ajedrez con diferentes modos de visualizac
    - **2**: resalta las casillas atacadas por la pieza seleccionada.
    - **3**: señala nuestras piezas en peligro.
    - **4**: indica las casillas desde las que podemos dar jaque.
+
+   Debajo de estas instrucciones ahora se muestra un indicador con los modos
+   activos para saber en todo momento qué vistas están habilitadas.
  
 La partida se juega haciendo clic o arrastrando las piezas hasta su destino. El turno comienza con blancas. En todo momento se muestran las piezas capturadas y un contador de tiempo para cada bando.
 

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     </div>
     <div id="info" class="info">
         <p>Presiona las teclas 1 a 4 para alternar las vistas. Se pueden combinar varias opciones a la vez.</p>
+        <p id="activeViews" class="views"></p>
     </div>
     <button id="settingsToggle">Ajustes</button>
     <div id="settingsMenu" class="settings hidden">

--- a/src/app.js
+++ b/src/app.js
@@ -486,6 +486,19 @@ function updateTimer() {
     }, 1000);
 }
 
+/**
+ * Display the currently active view modes on screen.
+ */
+function updateViewIndicator() {
+    const indicator = document.getElementById('activeViews');
+    if (!indicator) return;
+    if (activeViews.size === 0) {
+        indicator.textContent = 'Sin vistas activas';
+    } else {
+        indicator.textContent = 'Vistas activas: ' + [...activeViews].sort().join(', ');
+    }
+}
+
 // Allow quick view mode switch using number keys or numpad
 window.addEventListener('keydown', e => {
     let num = NaN;
@@ -500,6 +513,7 @@ window.addEventListener('keydown', e => {
         if (activeViews.has(num)) activeViews.delete(num);
         else activeViews.add(num);
         renderBoard();
+        updateViewIndicator();
         e.preventDefault();
     }
 });
@@ -521,3 +535,4 @@ initBoard();
 createBoard();
 updateCapturedDisplay();
 updateTimer();
+updateViewIndicator();

--- a/src/styles.css
+++ b/src/styles.css
@@ -105,6 +105,11 @@ h1 {
     display: none;
 }
 
+.views {
+    margin-top: 5px;
+    color: var(--neon-color);
+}
+
 .last-move {
     animation: flash 0.4s ease;
 }


### PR DESCRIPTION
## Summary
- display which view modes are active
- style active view indicator
- document view indicator in README

## Testing
- `node -c src/app.js`

------
https://chatgpt.com/codex/tasks/task_e_686189e448308333a2ff6ab60a1e4a5b