### PR TITLE
Add move history and PGN export

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,8 @@ Usa el botón **Ajustes** para abrir un panel donde puedes modificar:
   al propio rey en jaque, obligando a mover de forma legal en todo momento.
 * **Peón al paso**: cuando un peón avanza dos casillas desde su posición inicial
   puede ser capturado en la siguiente jugada como si solo hubiera avanzado una.
+
+## Historial de movimientos
+
+Debajo del tablero se muestra una lista con todas las jugadas realizadas en notación algebraica.
+Un botón permite exportar la partida en formato PGN para analizarla con otros programas.

--- a/index.html
+++ b/index.html
@@ -33,6 +33,11 @@
             <input type="range" id="neonBrightness" min="30" max="70" value="55">
         </label>
     </div>
+    <div id="moveContainer" class="moves">
+        <h2>Movimientos</h2>
+        <ol id="moveList"></ol>
+        <button id="exportPGN">Exportar PGN</button>
+    </div>
     <script src="src/app.js"></script>
 </body>
 </html>

--- a/src/app.js
+++ b/src/app.js
@@ -16,6 +16,7 @@ let capturedBlack = [];
 let whiteTime = 0;
 let blackTime = 0;
 let timerId = null;
+let moveHistory = [];
 
 const PIECES = {
     'p': '♟',
@@ -321,14 +322,14 @@ function inside(r,c) {
 
 /**
  * Update board state for a move without re-rendering the board.
- * Returns true if the move is legal and executed.
+ * Returns an object with the result of the move.
  */
 function executeMove(sr, sc, dr, dc) {
     const piece = board[sr][sc];
-    if (isWhite(piece) !== isWhiteTurn()) return false;
+    if (isWhite(piece) !== isWhiteTurn()) return { valid: false };
 
     const moves = legalMoves(sr, sc);
-    if (!moves.some(m => m[0] === dr && m[1] === dc)) return false;
+    if (!moves.some(m => m[0] === dr && m[1] === dc)) return { valid: false };
 
     let captured = board[dr][dc];
 
@@ -361,7 +362,8 @@ function executeMove(sr, sc, dr, dc) {
     turn = !turn;
     updateCapturedDisplay();
     updateTimer();
-    return true;
+    const check = isKingInCheck(turn);
+    return { valid: true, captured, check };
 }
 
 /**
@@ -402,8 +404,10 @@ function animateMove(sr, sc, dr, dc, piece) {
  */
 function movePiece(sr, sc, dr, dc) {
     const piece = board[sr][sc];
-    if (!executeMove(sr, sc, dr, dc)) return false;
+    const result = executeMove(sr, sc, dr, dc);
+    if (!result.valid) return false;
     lastMove = { from: [sr, sc], to: [dr, dc] };
+    recordMove(sr, sc, dr, dc, piece, result.captured, result.check);
     animateMove(sr, sc, dr, dc, piece);
     return true;
 }
@@ -486,6 +490,62 @@ function updateTimer() {
     }, 1000);
 }
 
+const FILES = ['a','b','c','d','e','f','g','h'];
+
+function squareName(row, col) {
+    return FILES[col] + (8 - row);
+}
+
+function toAlgebraic(sr, sc, dr, dc, piece, captured, check) {
+    const dest = squareName(dr, dc);
+    let notation;
+    if (piece.toLowerCase() === 'p') {
+        const file = FILES[sc];
+        notation = captured ? `${file}x${dest}` : dest;
+    } else {
+        notation = piece.toUpperCase() + (captured ? 'x' : '') + dest;
+    }
+    if (check) notation += '+';
+    return notation;
+}
+
+function recordMove(sr, sc, dr, dc, piece, captured, check) {
+    moveHistory.push(toAlgebraic(sr, sc, dr, dc, piece, captured, check));
+    updateMoveList();
+}
+
+function updateMoveList() {
+    const list = document.getElementById('moveList');
+    if (!list) return;
+    list.innerHTML = '';
+    for (let i = 0; i < moveHistory.length; i += 2) {
+        const li = document.createElement('li');
+        const white = moveHistory[i] || '';
+        const black = moveHistory[i + 1] || '';
+        li.textContent = `${Math.floor(i / 2) + 1}. ${white} ${black}`.trim();
+        list.appendChild(li);
+    }
+    list.scrollTop = list.scrollHeight;
+}
+
+function exportPGN() {
+    let pgn = '';
+    for (let i = 0; i < moveHistory.length; i += 2) {
+        const w = moveHistory[i] || '';
+        const b = moveHistory[i + 1] || '';
+        pgn += `${Math.floor(i / 2) + 1}. ${w} ${b} `;
+    }
+    const blob = new Blob([pgn.trim()], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'partida.pgn';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+}
+
 /**
  * Display the currently active view modes on screen.
  */
@@ -531,8 +591,12 @@ neonInput.addEventListener('input', () => {
     document.documentElement.style.setProperty('--neon-l', `${neonInput.value}%`);
 });
 
+const exportBtn = document.getElementById('exportPGN');
+if (exportBtn) exportBtn.addEventListener('click', exportPGN);
+
 initBoard();
 createBoard();
 updateCapturedDisplay();
 updateTimer();
 updateViewIndicator();
+updateMoveList();

--- a/src/styles.css
+++ b/src/styles.css
@@ -141,3 +141,18 @@ h1 {
 .captured div {
     margin-top: 5px;
 }
+
+.moves {
+    width: 480px;
+    margin: 20px auto;
+    text-align: left;
+    color: #cccccc;
+}
+
+.moves ol {
+    padding-left: 20px;
+}
+
+.moves button {
+    margin-top: 10px;
+}


### PR DESCRIPTION
## Summary
- track moves in `moveHistory` and show them on screen
- allow export of the game in PGN format
- style move list and add new section in the interface
- document new functionality in README

## Testing
- `node --check src/app.js`

------
https://chatgpt.com/codex/tasks/task_e_68618b4adc9c833399cadac53322a24d