### PR TITLE
Add selectable themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ajedrez Didáctico
 
-Esta aplicación web permite jugar al ajedrez con diferentes modos de visualización para ayudar al aprendizaje. Ahora cuenta con un tema oscuro de estilo neón para una experiencia moderna y agradable a la vista. Los movimientos se animan suavemente y se resalta la última jugada para seguir mejor el desarrollo de la partida.
+Esta aplicación web permite jugar al ajedrez con diferentes modos de visualización para ayudar al aprendizaje. Ahora se incluyen varios temas visuales —neón oscuro, clásico y alto contraste— para distinguir mejor entre piezas blancas y negras. Los movimientos se animan suavemente y se resalta la última jugada para seguir mejor el desarrollo de la partida.
 
 ## Uso
 
@@ -30,7 +30,8 @@ Usa el botón **Ajustes** para abrir un panel donde puedes modificar:
 - El tamaño de las piezas mediante un control deslizante (por defecto ahora se
   muestran más grandes).
 - El brillo del color neón del tema oscuro.
-- Dentro del submenú **Iluminación** puedes ajustar:
+- Elegir el tema visual entre neón oscuro (por defecto), clásico o alto contraste.
+  - Dentro del submenú **Iluminación** puedes ajustar:
   - La intensidad del resplandor que rodea tablero y resaltados.
   - La saturación del color neón.
 

--- a/index.html
+++ b/index.html
@@ -32,6 +32,13 @@
         <label>Brillo neón
             <input type="range" id="neonBrightness" min="30" max="70" value="55">
         </label>
+        <label>Tema
+            <select id="themeSelect">
+                <option value="neon" selected>Neón oscuro</option>
+                <option value="classic">Clásico</option>
+                <option value="contrast">Alto contraste</option>
+            </select>
+        </label>
         <details id="lightingSettings">
             <summary>Iluminación</summary>
             <label>Intensidad del resplandor

--- a/src/app.js
+++ b/src/app.js
@@ -5,6 +5,7 @@ const pieceSizeInput = document.getElementById('pieceSize');
 const neonInput = document.getElementById('neonBrightness');
 const glowInput = document.getElementById('glowIntensity');
 const saturationInput = document.getElementById('neonSaturation');
+const themeSelect = document.getElementById('themeSelect');
 
 // Board state and view configuration
 
@@ -96,9 +97,13 @@ function renderBoard() {
             const square = getSquareElement(row, col);
             const pieceEl = square.querySelector('.piece');
             pieceEl.textContent = '';
+            pieceEl.classList.remove('white-piece','black-piece');
             square.classList.remove('highlight','attack','danger','check','last-move');
             const piece = board[row][col];
-            if (piece) pieceEl.textContent = PIECES[piece];
+            if (piece) {
+                pieceEl.textContent = PIECES[piece];
+                pieceEl.classList.add(isWhite(piece) ? 'white-piece' : 'black-piece');
+            }
             pieceEl.draggable = !!piece && isWhite(piece) === isWhiteTurn();
         }
     }
@@ -398,6 +403,7 @@ function animateMove(sr, sc, dr, dc, piece) {
 
     const anim = document.createElement('div');
     anim.classList.add('anim-piece');
+    anim.classList.add(isWhite(piece) ? 'white-piece' : 'black-piece');
     anim.textContent = PIECES[piece];
     anim.style.left = (fromRect.left - boardRect.left) + 'px';
     anim.style.top = (fromRect.top - boardRect.top) + 'px';
@@ -487,8 +493,14 @@ function isKingInCheck(forWhite){
 }
 
 function updateCapturedDisplay() {
-    document.getElementById('capturedWhite').textContent = capturedWhite.map(p => PIECES[p]).join(' ');
-    document.getElementById('capturedBlack').textContent = capturedBlack.map(p => PIECES[p]).join(' ');
+    const whiteEl = document.getElementById('capturedWhite');
+    const blackEl = document.getElementById('capturedBlack');
+    whiteEl.innerHTML = capturedWhite
+        .map(p => `<span class="${isWhite(p) ? 'white-piece' : 'black-piece'}">${PIECES[p]}</span>`)
+        .join(' ');
+    blackEl.innerHTML = capturedBlack
+        .map(p => `<span class="${isWhite(p) ? 'white-piece' : 'black-piece'}">${PIECES[p]}</span>`)
+        .join(' ');
 }
 
 function formatTime(sec) {
@@ -660,6 +672,16 @@ glowInput.addEventListener('input', () => {
 saturationInput.addEventListener('input', () => {
     document.documentElement.style.setProperty('--neon-s', `${saturationInput.value}%`);
 });
+
+function applyTheme(theme) {
+    document.body.classList.remove('theme-neon', 'theme-classic', 'theme-contrast');
+    document.body.classList.add(`theme-${theme}`);
+}
+
+if (themeSelect) {
+    themeSelect.addEventListener('change', () => applyTheme(themeSelect.value));
+    applyTheme(themeSelect.value);
+}
 
 const exportBtn = document.getElementById('exportPGN');
 if (exportBtn) exportBtn.addEventListener('click', exportPGN);

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,6 +5,10 @@
     --glow-intensity: 15px;
     --neon-color: hsl(var(--neon-h), var(--neon-s), var(--neon-l));
     --piece-size: 48px;
+    --light-square-color: #1d1f21;
+    --dark-square-color: #111111;
+    --white-piece-color: #ffffff;
+    --black-piece-color: #bbbbbb;
 }
 
 body {
@@ -45,14 +49,24 @@ body {
     vertical-align: middle;
 }
 
+.white-piece {
+    color: var(--white-piece-color);
+}
 
-.light {
-    background-color: #1d1f21;
+.black-piece {
+    color: var(--black-piece-color);
 }
 
 
+
+.light {
+    background-color: var(--light-square-color);
+}
+
+
+
 .dark {
-    background-color: #111111;
+    background-color: var(--dark-square-color);
 }
 
 .highlight {
@@ -163,4 +177,29 @@ h1 {
 
 .moves button {
     margin-top: 10px;
+}
+
+/* Theme definitions */
+body.theme-neon {
+    --light-square-color: #1d1f21;
+    --dark-square-color: #111111;
+    --white-piece-color: #ffffff;
+    --black-piece-color: #bbbbbb;
+    background-color: #0d1117;
+}
+
+body.theme-classic {
+    --light-square-color: #f0d9b5;
+    --dark-square-color: #b58863;
+    --white-piece-color: #ffffff;
+    --black-piece-color: #000000;
+    background-color: #f5f5dc;
+}
+
+body.theme-contrast {
+    --light-square-color: #ffffff;
+    --dark-square-color: #000000;
+    --white-piece-color: #ffffff;
+    --black-piece-color: #000000;
+    background-color: #333333;
 }


### PR DESCRIPTION
## Summary
- style variables for piece colors and board squares
- color pieces using CSS classes
- add neon, classic and high-contrast themes
- allow changing theme from settings menu

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68618f1d61a483338d4845912562b0eb