### PR TITLE
Enhance chess animations with celebration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ajedrez Didáctico
 
-Esta aplicación web permite jugar al ajedrez con diferentes modos de visualización para ayudar al aprendizaje. Ahora se incluyen varios temas visuales —neón oscuro, clásico y alto contraste— para distinguir mejor entre piezas blancas y negras. Los movimientos se animan suavemente y se resalta la última jugada para seguir mejor el desarrollo de la partida.
+Esta aplicación web permite jugar al ajedrez con diferentes modos de visualización para ayudar al aprendizaje. Ahora se incluyen varios temas visuales —neón oscuro, clásico y alto contraste— para distinguir mejor entre piezas blancas y negras. Los movimientos cuentan con una animación más épica y, al capturar una pieza, aparece brevemente una celebración. También se resalta la última jugada para seguir mejor el desarrollo de la partida.
 
 ## Uso
 

--- a/src/app.js
+++ b/src/app.js
@@ -393,8 +393,10 @@ function executeMove(sr, sc, dr, dc) {
 
 /**
  * Animate a piece move from source to destination.
+ * If `captured` is provided, a celebration effect is shown
+ * on the destination square when the animation ends.
  */
-function animateMove(sr, sc, dr, dc, piece) {
+function animateMove(sr, sc, dr, dc, piece, captured) {
     const fromSquare = getSquareElement(sr, sc);
     const toSquare = getSquareElement(dr, dc);
     const boardRect = boardElement.getBoundingClientRect();
@@ -415,14 +417,31 @@ function animateMove(sr, sc, dr, dc, piece) {
     toSquare.querySelector('.piece').textContent = '';
 
     requestAnimationFrame(() => {
+        anim.classList.add('epic');
         anim.style.left = (toRect.left - boardRect.left) + 'px';
         anim.style.top = (toRect.top - boardRect.top) + 'px';
     });
 
     anim.addEventListener('transitionend', () => {
         anim.remove();
+        if (captured) showCaptureCelebration(toSquare);
         renderBoard();
     });
+}
+
+/**
+ * Show a short celebration animation when a capture occurs.
+ */
+function showCaptureCelebration(square) {
+    const boardRect = boardElement.getBoundingClientRect();
+    const rect = square.getBoundingClientRect();
+    const effect = document.createElement('div');
+    effect.classList.add('capture-celebration');
+    effect.textContent = '🎉';
+    effect.style.left = (rect.left - boardRect.left + rect.width / 2) + 'px';
+    effect.style.top = (rect.top - boardRect.top + rect.height / 2) + 'px';
+    boardElement.appendChild(effect);
+    effect.addEventListener('animationend', () => effect.remove());
 }
 
 /**
@@ -434,7 +453,7 @@ function movePiece(sr, sc, dr, dc) {
     if (!result.valid) return false;
     lastMove = { from: [sr, sc], to: [dr, dc] };
     recordMove(sr, sc, dr, dc, piece, result.captured, result.check);
-    animateMove(sr, sc, dr, dc, piece);
+    animateMove(sr, sc, dr, dc, piece, result.captured);
     return true;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -148,7 +148,13 @@ h1 {
     justify-content: center;
     font-size: var(--piece-size);
     pointer-events: none;
-    transition: left 0.2s ease-out, top 0.2s ease-out;
+    transition: left 0.3s cubic-bezier(0.34,1.56,0.64,1),
+                top 0.3s cubic-bezier(0.34,1.56,0.64,1),
+                transform 0.3s cubic-bezier(0.34,1.56,0.64,1);
+}
+
+.anim-piece.epic {
+    transform: scale(1.2) rotate(360deg);
 }
 
 .timer, .captured {
@@ -202,4 +208,20 @@ body.theme-contrast {
     --white-piece-color: #ffffff;
     --black-piece-color: #000000;
     background-color: #333333;
+}
+
+.capture-celebration {
+    position: absolute;
+    transform: translate(-50%, -50%);
+    font-size: calc(var(--piece-size) * 1.5);
+    color: gold;
+    text-shadow: 0 0 10px gold, 0 0 20px gold;
+    pointer-events: none;
+    animation: capture-celebration 0.6s ease-out forwards;
+}
+
+@keyframes capture-celebration {
+    0% { transform: translate(-50%, -50%) scale(0); opacity: 1; }
+    80% { transform: translate(-50%, -50%) scale(1.5); opacity: 1; }
+    100% { transform: translate(-50%, -50%) scale(1.5); opacity: 0; }
 }


### PR DESCRIPTION
## Summary
- animate piece movements with dramatic scaling and rotation
- display a short celebration when a capture occurs
- update README with new animation behaviour

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686304435c048333868d85dabddab160