### PR TITLE
Cache Chess.com user stats with refresh control

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ Un botón permite exportar la partida en formato PGN para analizarla con otros p
 
 El archivo `data-viz.html` ofrece estadísticas detalladas de tus partidas. Incluye gráficas de rachas ganadoras y perdedoras, análisis según descanso entre partidas y un listado de aperturas que puede filtrarse por color. Las gráficas de winrate muestran una línea con la media global de victorias para comparar cada categoría con tu rendimiento general. Mantén pulsada la barra espaciadora y haz clic en cualquier elemento informativo para que DeepSeek describa esa sección y te dé un consejo para mejorar en ajedrez.
 
+## Integración con Chess.com
+
+En la sección **Aprender** puedes cargar tu historial de partidas desde Chess.com.
+Los datos recuperados se guardan en el navegador durante 5 horas para evitar
+excesos de peticiones. Si necesitas información actualizada antes de ese plazo,
+usa el botón **Forzar descarga** para omitir la caché y traer la versión más reciente.
+
 ## Pruebas
 
 Se incluye un pequeño conjunto de pruebas para comprobar la lógica básica de puntuación del bot.

--- a/index 2.html
+++ b/index 2.html
@@ -84,6 +84,7 @@
                         <input id="ccUsername" type="text" placeholder="tu_usuario" style="width:160px">
                     </label>
                     <button id="loadStatsBtn" class="btn">Cargar historial</button>
+                    <button id="forceStatsBtn" class="btn ghost">Forzar descarga</button>
                     <label style="display:block; margin-top:8px">
                         <input type="checkbox" id="showPenalty" checked>
                         Mostrar % penalización en jugadas

--- a/index 3.html
+++ b/index 3.html
@@ -84,6 +84,7 @@
                         <input id="ccUsername" type="text" placeholder="tu_usuario" style="width:160px">
                     </label>
                     <button id="loadStatsBtn" class="btn">Cargar historial</button>
+                    <button id="forceStatsBtn" class="btn ghost">Forzar descarga</button>
                     <label style="display:block; margin-top:8px">
                         <input type="checkbox" id="showPenalty" checked>
                         Mostrar % penalización en jugadas

--- a/index.html
+++ b/index.html
@@ -90,6 +90,7 @@
                         <input id="ccUsername" type="text" placeholder="tu_usuario" style="width:160px">
                     </label>
                     <button id="loadStatsBtn" class="btn">Cargar historial</button>
+                    <button id="forceStatsBtn" class="btn ghost">Forzar descarga</button>
                     <label style="display:block; margin-top:8px">
                         <input type="checkbox" id="showPenalty" checked>
                         Mostrar % penalización en jugadas

--- a/src/app 2.js
+++ b/src/app 2.js
@@ -864,6 +864,7 @@ if (exportBtn) exportBtn.addEventListener('click', exportPGN);
 // Learning UI: username + load stats + toggle
 const ccInput = document.getElementById('ccUsername');
 const loadStatsBtn = document.getElementById('loadStatsBtn');
+const forceStatsBtn = document.getElementById('forceStatsBtn');
 const showPenaltyChk = document.getElementById('showPenalty');
 
 if (ccInput) {
@@ -878,39 +879,43 @@ if (showPenaltyChk) {
         if (selected) highlightMoves(selected.row, selected.col);
     });
 }
-if (loadStatsBtn) {
-    loadStatsBtn.addEventListener('click', async () => {
-        const u = (ccInput?.value||'').trim();
-        if (!u) { alert('Introduce tu usuario de Chess.com'); return; }
-        localStorage.setItem('cc_username', u);
-        const infoEl = document.getElementById('penaltyInfo');
-        const modelEl = document.getElementById('modelStatus');
-        if (infoEl) infoEl.textContent = 'Cargando historial…';
-        try {
-            userMoveStats = await window.ChessCom.loadUserMoveStats(u, { months: 'all' });
-            if (infoEl) infoEl.textContent = `Historial cargado (${userMoveStats.months} meses). Resalta casillas para ver %.`;
-            if (modelEl) {
-                const bm = userMoveStats.benchmark || {};
-                if (bm.samples) {
-                    const q = bm.quality || 'unknown';
-                    const ctx = Math.round((bm.ctxCoverage||0)*100);
-                    const ply = Math.round((bm.plyCoverage||0)*100);
-                    modelEl.textContent = `Modelo: ${q} • muestras ${bm.samples} • contexto ${ctx}% • ply ${ply}%`;
-                } else {
-                    modelEl.textContent = 'Modelo: sin benchmark disponible.';
-                }
+/**
+ * Retrieve move statistics for the given Chess.com user.
+ * When `force` is true, cached data is ignored and reloaded.
+ */
+async function handleLoadStats(force=false) {
+    const u = (ccInput?.value||'').trim();
+    if (!u) { alert('Introduce tu usuario de Chess.com'); return; }
+    localStorage.setItem('cc_username', u);
+    const infoEl = document.getElementById('penaltyInfo');
+    const modelEl = document.getElementById('modelStatus');
+    if (infoEl) infoEl.textContent = 'Cargando historial…';
+    try {
+        userMoveStats = await window.ChessCom.loadUserMoveStats(u, { months: 'all', force });
+        if (infoEl) infoEl.textContent = `Historial cargado (${userMoveStats.months} meses). Resalta casillas para ver %.`;
+        if (modelEl) {
+            const bm = userMoveStats.benchmark || {};
+            if (bm.samples) {
+                const q = bm.quality || 'unknown';
+                const ctx = Math.round((bm.ctxCoverage||0)*100);
+                const ply = Math.round((bm.plyCoverage||0)*100);
+                modelEl.textContent = `Modelo: ${q} • muestras ${bm.samples} • contexto ${ctx}% • ply ${ply}%`;
+            } else {
+                modelEl.textContent = 'Modelo: sin benchmark disponible.';
             }
-            renderBoard();
-            if (selected) highlightMoves(selected.row, selected.col);
-        } catch (e) {
-            console.error(e);
-            if (infoEl) infoEl.textContent = 'No se pudo cargar el historial.';
-            const modelEl2 = document.getElementById('modelStatus');
-            if (modelEl2) modelEl2.textContent = '';
-            alert('No se pudo cargar el historial de Chess.com. Verifica el usuario.');
         }
-    });
+        renderBoard();
+        if (selected) highlightMoves(selected.row, selected.col);
+    } catch (e) {
+        console.error(e);
+        if (infoEl) infoEl.textContent = 'No se pudo cargar el historial.';
+        const modelEl2 = document.getElementById('modelStatus');
+        if (modelEl2) modelEl2.textContent = '';
+        alert('No se pudo cargar el historial de Chess.com. Verifica el usuario.');
+    }
 }
+if (loadStatsBtn) loadStatsBtn.addEventListener('click', () => handleLoadStats(false));
+if (forceStatsBtn) forceStatsBtn.addEventListener('click', () => handleLoadStats(true));
 
 initBoard();
 createBoard();

--- a/src/app 3.js
+++ b/src/app 3.js
@@ -864,6 +864,7 @@ if (exportBtn) exportBtn.addEventListener('click', exportPGN);
 // Learning UI: username + load stats + toggle
 const ccInput = document.getElementById('ccUsername');
 const loadStatsBtn = document.getElementById('loadStatsBtn');
+const forceStatsBtn = document.getElementById('forceStatsBtn');
 const showPenaltyChk = document.getElementById('showPenalty');
 
 if (ccInput) {
@@ -878,39 +879,43 @@ if (showPenaltyChk) {
         if (selected) highlightMoves(selected.row, selected.col);
     });
 }
-if (loadStatsBtn) {
-    loadStatsBtn.addEventListener('click', async () => {
-        const u = (ccInput?.value||'').trim();
-        if (!u) { alert('Introduce tu usuario de Chess.com'); return; }
-        localStorage.setItem('cc_username', u);
-        const infoEl = document.getElementById('penaltyInfo');
-        const modelEl = document.getElementById('modelStatus');
-        if (infoEl) infoEl.textContent = 'Cargando historial…';
-        try {
-            userMoveStats = await window.ChessCom.loadUserMoveStats(u, { months: 'all' });
-            if (infoEl) infoEl.textContent = `Historial cargado (${userMoveStats.months} meses). Resalta casillas para ver %.`;
-            if (modelEl) {
-                const bm = userMoveStats.benchmark || {};
-                if (bm.samples) {
-                    const q = bm.quality || 'unknown';
-                    const ctx = Math.round((bm.ctxCoverage||0)*100);
-                    const ply = Math.round((bm.plyCoverage||0)*100);
-                    modelEl.textContent = `Modelo: ${q} • muestras ${bm.samples} • contexto ${ctx}% • ply ${ply}%`;
-                } else {
-                    modelEl.textContent = 'Modelo: sin benchmark disponible.';
-                }
+/**
+ * Retrieve move statistics for the given Chess.com user.
+ * When `force` is true, cached data is ignored and reloaded.
+ */
+async function handleLoadStats(force=false) {
+    const u = (ccInput?.value||'').trim();
+    if (!u) { alert('Introduce tu usuario de Chess.com'); return; }
+    localStorage.setItem('cc_username', u);
+    const infoEl = document.getElementById('penaltyInfo');
+    const modelEl = document.getElementById('modelStatus');
+    if (infoEl) infoEl.textContent = 'Cargando historial…';
+    try {
+        userMoveStats = await window.ChessCom.loadUserMoveStats(u, { months: 'all', force });
+        if (infoEl) infoEl.textContent = `Historial cargado (${userMoveStats.months} meses). Resalta casillas para ver %.`;
+        if (modelEl) {
+            const bm = userMoveStats.benchmark || {};
+            if (bm.samples) {
+                const q = bm.quality || 'unknown';
+                const ctx = Math.round((bm.ctxCoverage||0)*100);
+                const ply = Math.round((bm.plyCoverage||0)*100);
+                modelEl.textContent = `Modelo: ${q} • muestras ${bm.samples} • contexto ${ctx}% • ply ${ply}%`;
+            } else {
+                modelEl.textContent = 'Modelo: sin benchmark disponible.';
             }
-            renderBoard();
-            if (selected) highlightMoves(selected.row, selected.col);
-        } catch (e) {
-            console.error(e);
-            if (infoEl) infoEl.textContent = 'No se pudo cargar el historial.';
-            const modelEl2 = document.getElementById('modelStatus');
-            if (modelEl2) modelEl2.textContent = '';
-            alert('No se pudo cargar el historial de Chess.com. Verifica el usuario.');
         }
-    });
+        renderBoard();
+        if (selected) highlightMoves(selected.row, selected.col);
+    } catch (e) {
+        console.error(e);
+        if (infoEl) infoEl.textContent = 'No se pudo cargar el historial.';
+        const modelEl2 = document.getElementById('modelStatus');
+        if (modelEl2) modelEl2.textContent = '';
+        alert('No se pudo cargar el historial de Chess.com. Verifica el usuario.');
+    }
 }
+if (loadStatsBtn) loadStatsBtn.addEventListener('click', () => handleLoadStats(false));
+if (forceStatsBtn) forceStatsBtn.addEventListener('click', () => handleLoadStats(true));
 
 initBoard();
 createBoard();


### PR DESCRIPTION
## Summary
- Cache Chess.com move stats for 5 hours with optional forced refresh
- Add UI button to force refresh and update README

## Testing
- `node tests/evaluateMove.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b75a2ad7688333ab4b6227674b86bb