### PR TITLE
Fix local file cross-origin issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Esta aplicación web permite jugar al ajedrez con diferentes modos de visualizac
 
 ## Uso
 
-1. Abre `index.html` en tu navegador.
-2. Presiona las teclas numéricas (1 a 4) para alternar cada modo de vista. Puedes combinarlos:
+1. En una terminal, ejecuta `cd server && npm install && npm start` para iniciar el proxy local.
+2. Abre `http://localhost:8787` en tu navegador.
+3. Presiona las teclas numéricas (1 a 4) para alternar cada modo de vista. Puedes combinarlos:
    - **1**: muestra los movimientos disponibles al seleccionar o pasar el ratón sobre una pieza.
    - **2**: resalta las casillas atacadas por la pieza seleccionada.
    - **3**: señala nuestras piezas en peligro.

--- a/data-viz.html
+++ b/data-viz.html
@@ -6,6 +6,7 @@
     <title>Chess.com - Analizador de Usuario</title>
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link rel="preconnect" href="https://unpkg.com" crossorigin>
+    <link rel="icon" href="data:,">
     <style>
       :root{
         --bg:#0f1221;
@@ -386,6 +387,12 @@
       const $ = sel => document.querySelector(sel);
       const fmt = new Intl.NumberFormat('es-ES');
       const pct = v => (isFinite(v)? (v*100).toFixed(1)+'%':'—');
+
+      // Compute API base; if served from file:// use local proxy to avoid cross-origin errors
+      const defaultApiBase = () =>
+        (typeof location !== 'undefined' && location.protocol === 'file:')
+          ? 'http://localhost:8787/api/deepseek'
+          : '/api/deepseek';
 
       // API Chess.com
       const API = {
@@ -1405,7 +1412,7 @@
 
         // Load/save settings
         try {
-          apiBaseEl.value = localStorage.getItem('ds_api_base') || '/api/deepseek';
+          apiBaseEl.value = localStorage.getItem('ds_api_base') || defaultApiBase();
           modelEl.value = localStorage.getItem('ds_model') || 'deepseek-chat';
           useEl.checked = (localStorage.getItem('ds_use')||'false') === 'true';
           // Never auto-fill key into DOM value for safety; only keep in memory if present
@@ -2251,7 +2258,7 @@
           const apiKeyEl = document.getElementById('dsApiKey');
           const modelEl = document.getElementById('dsModel');
           const use = (localStorage.getItem('ds_use')||'false')==='true';
-          const base = apiBaseEl?.value?.trim() || '/api/deepseek';
+        const base = apiBaseEl?.value?.trim() || defaultApiBase();
           const key = apiKeyEl?.value?.trim() || '';
           const model = modelEl?.value || 'deepseek-chat';
 
@@ -2277,7 +2284,7 @@
         try{
           const sys = 'Eres un analista de rendimiento de ajedrez. Resume en español en 2-4 frases qué sugiere cada variable sobre el rendimiento del jugador. Sé conciso y claro.';
           const usr = `Variable: ${name}. Datos agregados: ${JSON.stringify(payload)}`;
-          const url = (base||'/api/deepseek').replace(/\/$/,'') + '/chat/completions';
+          const url = (base||defaultApiBase()).replace(/\/$/,'') + '/chat/completions';
           const body = { model: model||'deepseek-chat', messages: [ {role:'system', content: sys}, {role:'user', content: usr} ], temperature: 0.2 };
           const digest = stableHash(JSON.stringify({name,payload}));
           const ck = 'explain:'+ (model||'deepseek-chat') + ':' + digest;

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Orbitron&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="src/styles.css">
+    <link rel="icon" href="data:,">
 </head>
 <body>
     <header class="topbar">
@@ -138,7 +139,7 @@
                 Coach LLM (DeepSeek): comentarios y estilo
             </label>
             <div class="small muted" style="margin-top:4px">
-                Base API: <code>/api/deepseek</code> • Modelo: <code>deepseek-chat</code>
+                Base API: <code>/api/deepseek</code> (archivo: <code>http://localhost:8787/api/deepseek</code>) • Modelo: <code>deepseek-chat</code>
             </div>
             <label style="display:block; margin-top:6px">Profundidad
                 <input type="number" id="engineDepth" min="4" max="20" value="10" style="width:64px">

--- a/src/app.js
+++ b/src/app.js
@@ -1077,7 +1077,11 @@ let engineElo = 1600; // default strength target
 let usePersona = false;
 let useLLMCoach = false;
 let useLLMPick = false;
+// Determine API base; fall back to local proxy when loaded via file:// to avoid cross-origin errors
 let dsApiBase = '/api/deepseek';
+if (typeof location !== 'undefined' && location.protocol === 'file:') {
+    dsApiBase = 'http://localhost:8787/api/deepseek';
+}
 let dsModel = 'deepseek-chat';
 
 const useEngineChk = document.getElementById('useEngine');


### PR DESCRIPTION
## Summary
- Prevent cross-origin errors when loading pages from `file://` by routing API calls to `http://localhost:8787`.
- Provide inline favicon to suppress forbidden `file:///favicon.ico` requests.
- Document server startup and local URL in README.

## Testing
- `node tests/evaluateMove.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b75ead66e483338e6260664dcdd9d6