### PR TITLE
Enable Stockfish precision analysis for Chess.com data

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Al cargar datos de Chess.com, cada partida se evalúa automáticamente con Stock
 
 ## Análisis de precisión
 
-Al cargar datos de Chess.com, cada partida se evalúa automáticamente con Stockfish para estimar la pérdida media de centipeones de ambos jugadores. Los valores se guardan en `precision` (tu media) y `oppPrecision` (la del rival) y pueden utilizarse en las visualizaciones. Las evaluaciones se guardan en caché, evitando reprocesar partidas ya analizadas salvo que existan datos nuevos. En `data-viz.html` estas métricas aparecen en el listado de partidas y como columnas adicionales en la tabla de aperturas.
+Al cargar datos de Chess.com, cada partida se evalúa automáticamente con Stockfish para estimar la pérdida media de centipeones de ambos jugadores. Los valores se guardan en `precision` (tu media) y `oppPrecision` (la del rival) y pueden utilizarse en las visualizaciones. Las evaluaciones se guardan en caché, evitando reprocesar partidas ya analizadas salvo que existan datos nuevos. Para habilitar este cálculo, la página debe incluir el script `src/precision.js` y contar con un motor compatible en `src/stockfish.js`. En `data-viz.html` estas métricas aparecen en el listado de partidas y como columnas adicionales en la tabla de aperturas.
 
 ## Pruebas
 

--- a/data-viz.html
+++ b/data-viz.html
@@ -397,6 +397,7 @@
       </div>
     </div>
 
+    <script src="src/precision.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3"></script>
     <script>
@@ -526,7 +527,13 @@
         return moves;
       }
 
-      // Transformar juegos a dataset canónico
+      /**
+       * Normalize raw games from a monthly archive.
+       * Includes raw PGN so callers can run precision analysis.
+       * @param {Object} archData Monthly archive data.
+       * @param {string} username Username whose games are kept.
+       * @returns {Array<Object>} Normalized games.
+       */
       function normalizeGames(archData, username){
         const u = username.toLowerCase();
         const out = [];
@@ -570,6 +577,7 @@
             endTime, movesPlies,
             durationSec,
             movesSAN,
+            pgn,
           });
         }
         return out;
@@ -1360,6 +1368,19 @@
         // Normalizar todo
         setStatus('Procesando…');
         const allGames = monthsData.flatMap(m=> normalizeGames(m, username));
+
+        if(globalThis.GamePrecision && typeof globalThis.GamePrecision.analyzeGamePrecision === 'function'){
+          await pMap(allGames, async g => {
+            try{
+              const res = await globalThis.GamePrecision.analyzeGamePrecision(g.pgn || '');
+              g.precision = g.meColor === 'white' ? res.white : res.black;
+              g.oppPrecision = g.meColor === 'white' ? res.black : res.white;
+            }catch{}
+            delete g.pgn;
+          }, {concurrency:1});
+        } else {
+          allGames.forEach(g => { delete g.pgn; });
+        }
 
         // Agregar y pintar
         const mode = $('#modeFilter').value;

--- a/index.html
+++ b/index.html
@@ -173,6 +173,7 @@
     </div>
     <script src="src/ai-core.js"></script>
     <script src="src/fire.js"></script>
+    <script src="src/precision.js"></script>
     <script src="src/chesscom.js"></script>
     <script src="src/effects.js"></script>
     <!-- Si añades un build que exponga STOCKFISH() en el hilo principal,


### PR DESCRIPTION
## Summary
- load `precision.js` so pages can analyze Chess.com games with Stockfish
- compute and store per-game average centipawn loss in the visualizer
- document how to enable precision analysis

## Testing
- `node tests/evaluateMove.test.js`
- `node tests/precision.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b7664cca88833384314505ad147b18